### PR TITLE
Add delegate extractor to Instead the simple block

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,49 @@ end
 ---
 </details>
 
+<details>
+<summary>Delegate</summary>
+
+---
+
+You can use the delegate instead of the block.
+
+With Block:
+```ruby
+class ProjectBlueprint < Blueprinter::Base
+  identifier :uuid
+  field :company_name do |project, _options|
+    project.user.company
+  end
+end
+```
+
+Instead with Delegate:
+```ruby
+class ProjectBlueprint < Blueprinter::Base
+  identifier :uuid
+  field :company_name, delegate: { to: :user, source: :company }
+end
+```
+
+Usage:
+
+```ruby
+puts ProjectBlueprint.render(project)
+```
+
+Output:
+```json
+{
+  "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
+  "company_name": "My Company LLC"
+}
+
+```
+
+---
+</details>
+
 
 <details>
 <summary>Associations</summary>

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -7,6 +7,7 @@ require_relative 'extractors/auto_extractor'
 require_relative 'extractors/block_extractor'
 require_relative 'extractors/hash_extractor'
 require_relative 'extractors/public_send_extractor'
+require_relative 'extractors/delegate_extractor'
 require_relative 'formatters/date_time_formatter'
 require_relative 'field'
 require_relative 'helpers/type_helpers'
@@ -101,6 +102,12 @@ module Blueprinter
     #     field :full_name do |object, options|
     #       "options[:title_prefix] #{object.first_name} #{object.last_name}"
     #     end
+    #     # other code
+    #   end
+    #
+    # @example Passing a delegate method.
+    #   class UserBlueprint < Blueprinter::Base
+    #     field :city, delegate: { to: :city, source: :name }
     #     # other code
     #   end
     #

--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -8,6 +8,7 @@ module Blueprinter
       @public_send_extractor = PublicSendExtractor.new
       @block_extractor = BlockExtractor.new
       @datetime_formatter = DateTimeFormatter.new
+      @delegate_extractor = DelegateExtractor.new
     end
 
     def extract(field_name, object, local_options, options = {})
@@ -25,6 +26,8 @@ module Blueprinter
     def extractor(object, options)
       if options[:block]
         @block_extractor
+      elsif options[:delegate]
+        @delegate_extractor
       elsif object.is_a?(Hash)
         @hash_extractor
       else

--- a/lib/blueprinter/extractors/delegate_extractor.rb
+++ b/lib/blueprinter/extractors/delegate_extractor.rb
@@ -1,0 +1,15 @@
+module Blueprinter
+  # @api private
+  class DelegateExtractor < Extractor
+    DelegateArgumentError = Class.new(BlueprinterError)
+
+    def extract(field_name, object, _local_options, options = {})
+      delegate_options = options[:delegate]
+      raise(DelegateArgumentError, "#{field_name}: delegate[:to] need to define") unless delegate_options.has_key?(:to)
+      delegated_object = object.send(delegate_options[:to])
+      return nil if delegated_object.nil?
+      raise(DelegateArgumentError, "#{field_name}: delegate[:source] need to define") unless delegate_options.has_key?(:source)
+      delegated_object.send(delegate_options[:source])
+    end
+  end
+end

--- a/lib/blueprinter/extractors/delegate_extractor.rb
+++ b/lib/blueprinter/extractors/delegate_extractor.rb
@@ -6,10 +6,10 @@ module Blueprinter
     def extract(field_name, object, _local_options, options = {})
       delegate_options = options[:delegate]
       raise(DelegateArgumentError, "#{field_name}: delegate[:to] need to define") unless delegate_options.has_key?(:to)
-      delegated_object = object.send(delegate_options[:to])
+      delegated_object = object.public_send(delegate_options[:to])
       return nil if delegated_object.nil?
       raise(DelegateArgumentError, "#{field_name}: delegate[:source] need to define") unless delegate_options.has_key?(:source)
-      delegated_object.send(delegate_options[:source])
+      delegated_object.public_send(delegate_options[:source])
     end
   end
 end


### PR DESCRIPTION
Add delegate extractor to instead the simple block

With simple block
```ruby
class ProjectBlueprint < Blueprinter::Base
  identifier :uuid
  field :company_name do |project, _options|
    project.user.company
  end
end
```
and we can use
```ruby
class ProjectBlueprint < Blueprinter::Base
  identifier :uuid
  field :company_name, delegate: { to: :user, source: :company }
end
```

Usage:
```ruby
puts ProjectBlueprint.render(project)
```
Output:
```json
{
  "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
  "company_name": "My Company LLC"
}
```